### PR TITLE
Make creating namespaces optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ resource "kubernetes_secret_v1" "altinitycloud_cloud_connect" {
   count = var.pem != "" ? 1 : 0
   metadata {
     name      = "cloud-connect"
-    namespace = kubernetes_namespace_v1.altinitycloud_system.metadata[0].name
+    namespace = local.altinitycloud_system_namespace_id
     labels = {
       app = "cloud-connect"
     }
@@ -16,7 +16,7 @@ resource "kubernetes_secret_v1" "altinitycloud_cloud_connect" {
 resource "kubernetes_deployment_v1" "altinitycloud_cloud_connect" {
   metadata {
     name      = "cloud-connect"
-    namespace = kubernetes_namespace_v1.altinitycloud_system.metadata[0].name
+    namespace = local.altinitycloud_system_namespace_id
     labels = {
       app = "cloud-connect"
     }

--- a/ns.tf
+++ b/ns.tf
@@ -2,10 +2,39 @@ resource "kubernetes_namespace_v1" "altinitycloud_system" {
   metadata {
     name = "altinity-cloud-system"
   }
+  count = var.create_namespaces == true ? 1 : 0
 }
 
 resource "kubernetes_namespace_v1" "altinitycloud_managed_clickhouse" {
   metadata {
     name = "altinity-cloud-managed-clickhouse"
   }
+  count = var.create_namespaces == true ? 1 : 0
+}
+
+data "kubernetes_namespace_v1" "altinitycloud_system" {
+  metadata {
+    name = "altinity-cloud-system"
+  }
+  count = var.create_namespaces == false ? 1 : 0
+}
+
+data "kubernetes_namespace_v1" "altinitycloud_managed_clickhouse" {
+  metadata {
+    name = "altinity-cloud-managed-clickhouse"
+  }
+  count = var.create_namespaces == false ? 1 : 0
+}
+
+locals {
+  altinitycloud_system_namespace_id = (
+    length(kubernetes_namespace_v1.altinitycloud_system) > 0
+    ? kubernetes_namespace_v1.altinitycloud_system[0].metadata[0].name
+    : data.kubernetes_namespace_v1.altinitycloud_system[0].metadata[0].name
+  )
+  altinitycloud_managed_clickhouse_namespace_id = (
+    length(kubernetes_namespace_v1.altinitycloud_managed_clickhouse) > 0
+    ? kubernetes_namespace_v1.altinitycloud_managed_clickhouse[0].metadata[0].name
+    : data.kubernetes_namespace_v1.altinitycloud_managed_clickhouse[0].metadata[0].name
+  )
 }

--- a/rbac.tf
+++ b/rbac.tf
@@ -72,7 +72,7 @@ resource "kubernetes_cluster_role_v1" "altinitycloud_cloud_connect" {
 resource "kubernetes_service_account_v1" "altinitycloud_cloud_connect" {
   metadata {
     name      = "cloud-connect"
-    namespace = kubernetes_namespace_v1.altinitycloud_system.metadata[0].name
+    namespace = local.altinitycloud_system_namespace_id
   }
 }
 
@@ -109,17 +109,17 @@ resource "kubernetes_cluster_role_binding_v1" "altinitycloud_node_view" {
   subject {
     kind      = "ServiceAccount"
     name      = "edge-proxy"
-    namespace = kubernetes_namespace_v1.altinitycloud_system.metadata[0].name
+    namespace = local.altinitycloud_system_namespace_id
   }
   subject {
     kind      = "ServiceAccount"
     name      = "prometheus"
-    namespace = kubernetes_namespace_v1.altinitycloud_system.metadata[0].name
+    namespace = local.altinitycloud_system_namespace_id
   }
   subject {
     kind      = "ServiceAccount"
     name      = "kube-state-metrics"
-    namespace = kubernetes_namespace_v1.altinitycloud_system.metadata[0].name
+    namespace = local.altinitycloud_system_namespace_id
   }
 }
 
@@ -135,7 +135,7 @@ resource "kubernetes_cluster_role_binding_v1" "altinitycloud_node_metrics_view" 
   subject {
     kind      = "ServiceAccount"
     name      = "prometheus"
-    namespace = kubernetes_namespace_v1.altinitycloud_system.metadata[0].name
+    namespace = local.altinitycloud_system_namespace_id
   }
 }
 
@@ -172,14 +172,14 @@ resource "kubernetes_cluster_role_binding_v1" "altinitycloud_persistent_volume_v
   subject {
     kind      = "ServiceAccount"
     name      = "kube-state-metrics"
-    namespace = kubernetes_namespace_v1.altinitycloud_system.metadata[0].name
+    namespace = local.altinitycloud_system_namespace_id
   }
 }
 
 resource "kubernetes_role_binding_v1" "altinitycloud_cloud_connect_system" {
   metadata {
     name      = "altinity-cloud:cloud-connect"
-    namespace = kubernetes_namespace_v1.altinitycloud_system.metadata[0].name
+    namespace = local.altinitycloud_system_namespace_id
   }
   role_ref {
     api_group = "rbac.authorization.k8s.io"
@@ -196,7 +196,7 @@ resource "kubernetes_role_binding_v1" "altinitycloud_cloud_connect_system" {
 resource "kubernetes_role_binding_v1" "altinitycloud_cloud_connect_managed_clickhouse" {
   metadata {
     name      = "altinity-cloud:cloud-connect"
-    namespace = kubernetes_namespace_v1.altinitycloud_managed_clickhouse.metadata[0].name
+    namespace = local.altinitycloud_managed_clickhouse_namespace_id
   }
   role_ref {
     api_group = "rbac.authorization.k8s.io"

--- a/variables.tf
+++ b/variables.tf
@@ -26,3 +26,16 @@ variable "image_pull_policy" {
   description = "Image pull policy as described in https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy (defaults to \"IfNotPresent\" except when referred to latest master (in which case it's \"Always\"))"
   default     = ""
 }
+
+variable "create_namespaces" {
+  type        = bool
+  default     = true
+  description = <<EOT
+By default, the module will create two namespaces: `altinity-cloud-system` and
+`altinity-cloud-managed-clickhouse`.  Set this to `false` if you need to pre-create
+those namespaces in your calling module (e.g. to add annotations or non-altinity
+pods).  If you do this, you _must_ create both namespaces, and you will need to
+manually use the `depends_on` meta-variable to make this module not instantiate
+until after they are created.
+EOT
+}


### PR DESCRIPTION
The calling module may need to pre-create the k8s namespaces (e.g. to add labels/annotations to them, or to pre-populate them with PVCs or other resources) -- add a boolean variable that skips creating the namespaces if set to true.